### PR TITLE
Feature: box/spout to openspout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "Symfony datatable",
     "type": "symfony-bundle",
     "require": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0",
         "ext-json": "*",
-        "openspout/openspout": "^3.3",
+        "openspout/openspout": "^4.6",
         "symfony/translation": "^6.0",
         "symfony/options-resolver": "^6.0",
         "symfony/http-foundation": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Symfony datatable",
     "type": "symfony-bundle",
     "require": {
-        "php": "^7.4",
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
         "ext-json": "*",
         "openspout/openspout": "^3.3",
         "symfony/translation": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
         "ext-json": "*",
         "openspout/openspout": "^3.3",
-        "symfony/translation": "^5.0",
-        "symfony/options-resolver": "^5.0",
-        "symfony/http-foundation": "^5.0",
-        "symfony/http-kernel": "^5.0",
-        "symfony/dependency-injection": "^5.0",
+        "symfony/translation": "^6.0",
+        "symfony/options-resolver": "^6.0",
+        "symfony/http-foundation": "^6.0",
+        "symfony/http-kernel": "^6.0",
+        "symfony/dependency-injection": "^6.0",
         "doctrine/orm": "^2.7",
-        "symfony/twig-bundle": "^5.0",
-        "symfony/config": "^5.0"
+        "symfony/twig-bundle": "^6.0",
+        "symfony/config": "^6.0"
     },
     "suggest": {
         "symfony/webpack-encore-bundle": "To manage the building and creating of your frontend files"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.4",
         "ext-json": "*",
-        "box/spout": "^3.3",
+        "openspout/openspout": "^3.3",
         "symfony/translation": "^5.0",
         "symfony/options-resolver": "^5.0",
         "symfony/http-foundation": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
         "php": "~8.0.0 || ~8.1.0",
         "ext-json": "*",
         "openspout/openspout": "^4.6",
-        "symfony/translation": "^6.0",
-        "symfony/options-resolver": "^6.0",
-        "symfony/http-foundation": "^6.0",
-        "symfony/http-kernel": "^6.0",
-        "symfony/dependency-injection": "^6.0",
+        "symfony/translation": "^5.4 || ^6.0",
+        "symfony/options-resolver": "^5.4 || ^6.0",
+        "symfony/http-foundation": "^5.4 || ^6.0",
+        "symfony/http-kernel": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0",
         "doctrine/orm": "^2.7",
-        "symfony/twig-bundle": "^6.0",
-        "symfony/config": "^6.0"
+        "symfony/twig-bundle": "^5.4 || ^6.0",
+        "symfony/config": "^5.4  || ^6.0"
     },
     "suggest": {
         "symfony/webpack-encore-bundle": "To manage the building and creating of your frontend files"

--- a/src/DataTableExportAdapter.php
+++ b/src/DataTableExportAdapter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Webmen\DataTableBundle;
 
-use Box\Spout\Writer\Common\Creator\WriterEntityFactory;
+use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Security;

--- a/src/DataTableExportAdapter.php
+++ b/src/DataTableExportAdapter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Webmen\DataTableBundle;
 
 use OpenSpout\Common\Entity\Row;
-use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
 use Doctrine\ORM\QueryBuilder;
 use OpenSpout\Writer\XLSX\Writer;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/DataTableExportAdapter.php
+++ b/src/DataTableExportAdapter.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Webmen\DataTableBundle;
 
+use OpenSpout\Common\Entity\Row;
 use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
 use Doctrine\ORM\QueryBuilder;
+use OpenSpout\Writer\XLSX\Writer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -50,14 +52,14 @@ final class DataTableExportAdapter implements DataTableExportInterface
         $filename = sprintf('%s-%s', (new \DateTime())->format('YmdHis'), $dataTableName);
         $fullName = sprintf('%s/%s.xlsx', $this->exportDatatableDirectory, $filename);
 
-        $writer = WriterEntityFactory::createXLSXWriter();
+        $writer = new Writer();
         $writer->openToFile($fullName);
 
-        $singleRow = WriterEntityFactory::createRowFromArray($this->getHeaders());
+        $singleRow = Row::fromValues($this->getHeaders());
         $writer->addRow($singleRow);
 
         foreach ($queryBuilder->getQuery()->toIterable() as $row) {
-            $singleRow = WriterEntityFactory::createRowFromArray($this->serializeExport($row));
+            $singleRow = Row::fromValues($this->serializeExport($row));
             $writer->addRow($singleRow);
         }
         $writer->close();


### PR DESCRIPTION
This PR replaces `box/spout` with openspout.
Also updates to openspout 4.x and made the module PHP8.x compatible.

**How to test**
- [x] Find the demo app in our private GitLab instance; `robertvanlienden/datatable-demo-app`
- [x] Go to the datatable mentioned in the `README.md` of the demo app
- [x] Create some records and after that use the "export" button on top of the datatable
- [x] Find the export you've made in `files/export-datatable`